### PR TITLE
fix: do not report start_signals as an alarm

### DIFF
--- a/src/VariableSpeedMaster.cpp
+++ b/src/VariableSpeedMaster.cpp
@@ -1,5 +1,5 @@
-#include <genset_whisperpower_ddc/VariableSpeedMaster.hpp>
 #include <genset_whisperpower_ddc/VariableSpeed.hpp>
+#include <genset_whisperpower_ddc/VariableSpeedMaster.hpp>
 #include <iostream>
 
 #define PI 3.141592653589793
@@ -7,55 +7,74 @@
 using namespace std;
 using namespace genset_whisperpower_ddc;
 
-int VariableSpeedMaster::extractPacket(uint8_t const* buffer, size_t bufferSize) const {
-    throw std::logic_error("genset_whisperpower_dcc::VariableSpeedMaster should be read only using readRaw");
+int VariableSpeedMaster::extractPacket(uint8_t const* buffer, size_t bufferSize) const
+{
+    throw std::logic_error(
+        "genset_whisperpower_dcc::VariableSpeedMaster should be read only using readRaw");
 }
 
-VariableSpeedMaster::VariableSpeedMaster() : iodrivers_base::Driver(variable_speed::RECEIVED_FRAME_SIZE * 10) {
+VariableSpeedMaster::VariableSpeedMaster()
+    : iodrivers_base::Driver(variable_speed::RECEIVED_FRAME_SIZE * 10)
+{
     setReadTimeout(base::Time::fromSeconds(1));
     m_read_buffer.resize(MAX_PACKET_SIZE);
     m_write_buffer.resize(MAX_PACKET_SIZE);
 }
 
-
-Frame VariableSpeedMaster::readFrame() {
+Frame VariableSpeedMaster::readFrame()
+{
     Frame result;
     readFrame(result);
     return result;
 }
 
-void VariableSpeedMaster::readFrame(Frame& frame) {
-    int c = readRaw(&m_read_buffer[0], m_read_buffer.size(),
-                    getReadTimeout(), getReadTimeout(), m_interframe_delay);
+void VariableSpeedMaster::readFrame(Frame& frame)
+{
+    int c = readRaw(&m_read_buffer[0],
+        m_read_buffer.size(),
+        getReadTimeout(),
+        getReadTimeout(),
+        m_interframe_delay);
 
     variable_speed::parseFrame(frame, &m_read_buffer[0], &m_read_buffer[c]);
 }
 
-void VariableSpeedMaster::writeFrame(uint8_t command, std::vector<uint8_t> const& payload) {
+void VariableSpeedMaster::writeFrame(uint8_t command, std::vector<uint8_t> const& payload)
+{
     uint8_t* start = &m_write_buffer[0];
-    uint8_t const* end = variable_speed::formatFrame(start, variable_speed::DDC_CONTROLLER_ADDRESS, variable_speed::PANELS_ADDRESS, command, payload);
+    uint8_t const* end = variable_speed::formatFrame(start,
+        variable_speed::DDC_CONTROLLER_ADDRESS,
+        variable_speed::PANELS_ADDRESS,
+        command,
+        payload);
     writePacket(&m_write_buffer[0], end - start);
 }
 
-void VariableSpeedMaster::sendControlCommand(uint8_t controlCommand) {
-    std::vector<uint8_t> payload = variable_speed::formatStartStopCommandData(controlCommand);
+void VariableSpeedMaster::sendControlCommand(uint8_t controlCommand)
+{
+    std::vector<uint8_t> payload =
+        variable_speed::formatStartStopCommandData(controlCommand);
     writeFrame(variable_speed::PACKET_START_STOP, payload);
 }
 
-std::pair<GeneratorState, GeneratorModel> VariableSpeedMaster::parseGeneratorStateAndModel(std::vector<uint8_t> payload, base::Time const& time)
+std::pair<GeneratorState, GeneratorModel> VariableSpeedMaster::
+    parseGeneratorStateAndModel(std::vector<uint8_t> payload, base::Time const& time)
 {
     GeneratorState generator_state;
     GeneratorModel generator_model;
 
     generator_state.time = time;
-    generator_state.rotation_speed = ((2*PI)/60)*((payload[1] << 8) | payload[0]); // convert rpm to rad/s
+    generator_state.rotation_speed =
+        ((2 * PI) / 60) * ((payload[1] << 8) | payload[0]); // convert rpm to rad/s
     generator_state.start_battery_voltage = 0.01 * ((payload[3] << 8) | payload[2]);
-    generator_state.alarms = (payload[5] << 8) | payload[4];
+    generator_state.alarms = ((payload[5] & 0x15f) << 8) |
+                             payload[4]; // remove bits 5 and 7 (start_signals bits)
+
     generator_state.start_signals = payload[5];
-    if (payload[7] < 0x0E){
+    if (payload[7] < 0x0E) {
         generator_state.generator_status = static_cast<GeneratorStatus>(payload[7]);
     }
-    else{
+    else {
         generator_state.generator_status = STATUS_UNKNOWN;
     }
 
@@ -66,7 +85,8 @@ std::pair<GeneratorState, GeneratorModel> VariableSpeedMaster::parseGeneratorSta
     return std::make_pair(generator_state, generator_model);
 }
 
-RunTimeState VariableSpeedMaster::parseRunTimeState(std::vector<uint8_t> payload, base::Time const& time)
+RunTimeState VariableSpeedMaster::parseRunTimeState(std::vector<uint8_t> payload,
+    base::Time const& time)
 {
     RunTimeState run_time_state;
 
@@ -74,11 +94,13 @@ RunTimeState VariableSpeedMaster::parseRunTimeState(std::vector<uint8_t> payload
 
     int minutes = payload[0];
     int hours = (payload[3] << 16) | (payload[2] << 8) | payload[1];
-    run_time_state.total_run_time = base::Time::fromSeconds((hours * 60 * 60) + (minutes * 60));
+    run_time_state.total_run_time =
+        base::Time::fromSeconds((hours * 60 * 60) + (minutes * 60));
 
     minutes = payload[4];
     hours = (payload[7] << 16) | (payload[6] << 8) | payload[5];
-    run_time_state.historical_run_time = base::Time::fromSeconds((hours * 60 * 60) + (minutes * 60));
+    run_time_state.historical_run_time =
+        base::Time::fromSeconds((hours * 60 * 60) + (minutes * 60));
 
     return run_time_state;
 }

--- a/test/test_VariableSpeedMaster.cpp
+++ b/test/test_VariableSpeedMaster.cpp
@@ -1,27 +1,31 @@
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-#include <genset_whisperpower_ddc/VariableSpeedMaster.hpp>
-#include <genset_whisperpower_ddc/VariableSpeed.hpp>
-#include <iodrivers_base/FixtureGTest.hpp>
 #include <fcntl.h>
+#include <genset_whisperpower_ddc/VariableSpeed.hpp>
+#include <genset_whisperpower_ddc/VariableSpeedMaster.hpp>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <iodrivers_base/FixtureGTest.hpp>
 #include <thread>
 
 #define PI 3.141592653589793
 
 using namespace std;
 using namespace genset_whisperpower_ddc;
-using testing::ElementsAreArray;
 using base::Time;
+using testing::ElementsAreArray;
 
-struct VariableSpeedMasterTest : public ::testing::Test, iodrivers_base::Fixture<VariableSpeedMaster> {
-    VariableSpeedMasterTest() {
+struct VariableSpeedMasterTest : public ::testing::Test,
+                                 iodrivers_base::Fixture<VariableSpeedMaster> {
+    VariableSpeedMasterTest()
+    {
     }
 
-    ~VariableSpeedMasterTest() {
+    ~VariableSpeedMasterTest()
+    {
     }
 };
 
-TEST_F(VariableSpeedMasterTest, it_throws_if_calling_readPacket) {
+TEST_F(VariableSpeedMasterTest, it_throws_if_calling_readPacket)
+{
     driver.openURI("test://");
     // push one byte to get into extractPacket
     uint8_t buffer[1];
@@ -29,49 +33,97 @@ TEST_F(VariableSpeedMasterTest, it_throws_if_calling_readPacket) {
     ASSERT_THROW(driver.readPacket(buffer, 1024), std::logic_error);
 }
 
-TEST_F(VariableSpeedMasterTest, it_reads_a_frame) {
+TEST_F(VariableSpeedMasterTest, it_reads_a_frame)
+{
     driver.openURI("test://");
 
-    std::vector<uint8_t> buffer = { variable_speed::PANELS_ADDRESS & 0xFF, (variable_speed::PANELS_ADDRESS >> 8) & 0xFF, variable_speed::DDC_CONTROLLER_ADDRESS & 0xFF,
-                           (variable_speed::DDC_CONTROLLER_ADDRESS >> 8) & 0xFF, variable_speed::PACKET_GENERATOR_STATE_AND_MODEL, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0x38 };
+    std::vector<uint8_t> buffer = {variable_speed::PANELS_ADDRESS & 0xFF,
+        (variable_speed::PANELS_ADDRESS >> 8) & 0xFF,
+        variable_speed::DDC_CONTROLLER_ADDRESS & 0xFF,
+        (variable_speed::DDC_CONTROLLER_ADDRESS >> 8) & 0xFF,
+        variable_speed::PACKET_GENERATOR_STATE_AND_MODEL,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        0x38};
     pushDataToDriver(&buffer[0], &buffer[16]);
 
     Frame frame = driver.readFrame();
     ASSERT_EQ(variable_speed::PANELS_ADDRESS, frame.targetID);
     ASSERT_EQ(variable_speed::DDC_CONTROLLER_ADDRESS, frame.sourceID);
     ASSERT_EQ(variable_speed::PACKET_GENERATOR_STATE_AND_MODEL, frame.command);
-    uint8_t payload[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    uint8_t payload[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     ASSERT_THAT(frame.payload, ElementsAreArray(payload));
 }
 
-TEST_F(VariableSpeedMasterTest, it_writes_a_frame) {
+TEST_F(VariableSpeedMasterTest, it_writes_a_frame)
+{
     driver.openURI("test://");
 
-    driver.writeFrame(variable_speed::PACKET_START_STOP, std::vector<uint8_t> {0, 1, 2, 3});
+    driver.writeFrame(variable_speed::PACKET_START_STOP,
+        std::vector<uint8_t>{0, 1, 2, 3});
     auto bytes = readDataFromDriver();
 
-    uint8_t expected[] = { variable_speed::DDC_CONTROLLER_ADDRESS & 0xFF, (variable_speed::DDC_CONTROLLER_ADDRESS >> 8) & 0xFF, variable_speed::PANELS_ADDRESS & 0xFF,
-                           (variable_speed::PANELS_ADDRESS >> 8) & 0xFF, variable_speed::PACKET_START_STOP, 0x00, 0x01, 0x02, 0x03, 0x06 };
+    uint8_t expected[] = {variable_speed::DDC_CONTROLLER_ADDRESS & 0xFF,
+        (variable_speed::DDC_CONTROLLER_ADDRESS >> 8) & 0xFF,
+        variable_speed::PANELS_ADDRESS & 0xFF,
+        (variable_speed::PANELS_ADDRESS >> 8) & 0xFF,
+        variable_speed::PACKET_START_STOP,
+        0x00,
+        0x01,
+        0x02,
+        0x03,
+        0x06};
     ASSERT_THAT(bytes, ElementsAreArray(expected));
 }
 
-
-TEST_F(VariableSpeedMasterTest, it_sends_control_command) {
+TEST_F(VariableSpeedMasterTest, it_sends_control_command)
+{
     driver.openURI("test://");
 
     driver.sendControlCommand(variable_speed::PACKET_GENERATOR_STATE_AND_MODEL);
     auto bytes = readDataFromDriver();
 
-    uint8_t expected[] = { variable_speed::DDC_CONTROLLER_ADDRESS & 0xFF, (variable_speed::DDC_CONTROLLER_ADDRESS >> 8) & 0xFF, variable_speed::PANELS_ADDRESS & 0xFF,
-                           (variable_speed::PANELS_ADDRESS >> 8) & 0xFF, variable_speed::PACKET_START_STOP, variable_speed::PACKET_GENERATOR_STATE_AND_MODEL, 0x00, 0x00, 0x00, 0x02 };
-     ASSERT_THAT(bytes, ElementsAreArray(expected));
+    uint8_t expected[] = {variable_speed::DDC_CONTROLLER_ADDRESS & 0xFF,
+        (variable_speed::DDC_CONTROLLER_ADDRESS >> 8) & 0xFF,
+        variable_speed::PANELS_ADDRESS & 0xFF,
+        (variable_speed::PANELS_ADDRESS >> 8) & 0xFF,
+        variable_speed::PACKET_START_STOP,
+        variable_speed::PACKET_GENERATOR_STATE_AND_MODEL,
+        0x00,
+        0x00,
+        0x00,
+        0x02};
+    ASSERT_THAT(bytes, ElementsAreArray(expected));
 }
 
-TEST_F(VariableSpeedMasterTest, it_parses_generator_state_and_model) {
+TEST_F(VariableSpeedMasterTest, it_parses_generator_state_and_model)
+{
     driver.openURI("test://");
 
-    std::vector<uint8_t> buffer = { variable_speed::PANELS_ADDRESS & 0xFF, (variable_speed::PANELS_ADDRESS >> 8) & 0xFF, variable_speed::DDC_CONTROLLER_ADDRESS & 0xFF,
-                           (variable_speed::DDC_CONTROLLER_ADDRESS >> 8) & 0xFF, variable_speed::PACKET_GENERATOR_STATE_AND_MODEL, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0x38 };
+    std::vector<uint8_t> buffer = {variable_speed::PANELS_ADDRESS & 0xFF,
+        (variable_speed::PANELS_ADDRESS >> 8) & 0xFF,
+        variable_speed::DDC_CONTROLLER_ADDRESS & 0xFF,
+        (variable_speed::DDC_CONTROLLER_ADDRESS >> 8) & 0xFF,
+        variable_speed::PACKET_GENERATOR_STATE_AND_MODEL,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        0x38};
     pushDataToDriver(&buffer[0], &buffer[16]);
 
     Frame frame = driver.readFrame();
@@ -79,11 +131,12 @@ TEST_F(VariableSpeedMasterTest, it_parses_generator_state_and_model) {
     ASSERT_EQ(variable_speed::PACKET_GENERATOR_STATE_AND_MODEL, frame.command);
 
     Time now = Time::now();
-    std::pair<GeneratorState, GeneratorModel> generatorStateAndModel = driver.parseGeneratorStateAndModel(frame.payload, now);
+    std::pair<GeneratorState, GeneratorModel> generatorStateAndModel =
+        driver.parseGeneratorStateAndModel(frame.payload, now);
 
     GeneratorState expectedState;
     expectedState.time = now;
-    expectedState.rotation_speed = ((2*PI)/60) * 0x0100;
+    expectedState.rotation_speed = ((2 * PI) / 60) * 0x0100;
     expectedState.start_battery_voltage = 0.01 * 0x0302;
     expectedState.alarms = 0x0504;
     expectedState.start_signals = 0x05;
@@ -95,20 +148,94 @@ TEST_F(VariableSpeedMasterTest, it_parses_generator_state_and_model) {
 
     ASSERT_EQ(generatorStateAndModel.first.time, expectedState.time);
     ASSERT_EQ(generatorStateAndModel.first.rotation_speed, expectedState.rotation_speed);
-    ASSERT_EQ(generatorStateAndModel.first.start_battery_voltage, expectedState.start_battery_voltage);
+    ASSERT_EQ(generatorStateAndModel.first.start_battery_voltage,
+        expectedState.start_battery_voltage);
     ASSERT_EQ(generatorStateAndModel.first.alarms, expectedState.alarms);
     ASSERT_EQ(generatorStateAndModel.first.start_signals, expectedState.start_signals);
-    ASSERT_EQ(generatorStateAndModel.first.generator_status, expectedState.generator_status);
+    ASSERT_EQ(generatorStateAndModel.first.generator_status,
+        expectedState.generator_status);
 
-    ASSERT_EQ(generatorStateAndModel.second.model_detection, expectedModel.model_detection);
+    ASSERT_EQ(generatorStateAndModel.second.model_detection,
+        expectedModel.model_detection);
     ASSERT_EQ(generatorStateAndModel.second.generator_type, expectedModel.generator_type);
 }
 
-TEST_F(VariableSpeedMasterTest, it_parses_run_time_state) {
+TEST_F(VariableSpeedMasterTest, it_does_not_fill_alarms_bits_with_start_signals_bits)
+{
     driver.openURI("test://");
 
-    std::vector<uint8_t> buffer = { variable_speed::PANELS_ADDRESS & 0xFF, (variable_speed::PANELS_ADDRESS >> 8) & 0xFF, variable_speed::DDC_CONTROLLER_ADDRESS & 0xFF,
-                           (variable_speed::DDC_CONTROLLER_ADDRESS >> 8) & 0xFF, variable_speed::PACKET_RUN_TIME_STATE, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0x44 };
+    std::vector<uint8_t> buffer = {variable_speed::PANELS_ADDRESS & 0xFF,
+        (variable_speed::PANELS_ADDRESS >> 8) & 0xFF,
+        variable_speed::DDC_CONTROLLER_ADDRESS & 0xFF,
+        (variable_speed::DDC_CONTROLLER_ADDRESS >> 8) & 0xFF,
+        variable_speed::PACKET_GENERATOR_STATE_AND_MODEL,
+        0,
+        1,
+        2,
+        3,
+        4,
+        32,
+        6,
+        7,
+        8,
+        9,
+        83};
+    pushDataToDriver(&buffer[0], &buffer[16]);
+
+    Frame frame = driver.readFrame();
+
+    ASSERT_EQ(variable_speed::PACKET_GENERATOR_STATE_AND_MODEL, frame.command);
+
+    Time now = Time::now();
+    std::pair<GeneratorState, GeneratorModel> generatorStateAndModel =
+        driver.parseGeneratorStateAndModel(frame.payload, now);
+
+    GeneratorState expectedState;
+    expectedState.time = now;
+    expectedState.rotation_speed = ((2 * PI) / 60) * 0x0100;
+    expectedState.start_battery_voltage = 0.01 * 0x0302;
+    expectedState.alarms = 0x04;
+    expectedState.start_signals = 0x20;
+    expectedState.generator_status = GeneratorStatus::STATUS_PRESENT;
+
+    GeneratorModel expectedModel;
+    expectedModel.model_detection = 0x06;
+    expectedModel.generator_type = 0x08;
+
+    ASSERT_EQ(generatorStateAndModel.first.time, expectedState.time);
+    ASSERT_EQ(generatorStateAndModel.first.rotation_speed, expectedState.rotation_speed);
+    ASSERT_EQ(generatorStateAndModel.first.start_battery_voltage,
+        expectedState.start_battery_voltage);
+    ASSERT_EQ(generatorStateAndModel.first.alarms, expectedState.alarms);
+    ASSERT_EQ(generatorStateAndModel.first.start_signals, expectedState.start_signals);
+    ASSERT_EQ(generatorStateAndModel.first.generator_status,
+        expectedState.generator_status);
+
+    ASSERT_EQ(generatorStateAndModel.second.model_detection,
+        expectedModel.model_detection);
+    ASSERT_EQ(generatorStateAndModel.second.generator_type, expectedModel.generator_type);
+}
+
+TEST_F(VariableSpeedMasterTest, it_parses_run_time_state)
+{
+    driver.openURI("test://");
+
+    std::vector<uint8_t> buffer = {variable_speed::PANELS_ADDRESS & 0xFF,
+        (variable_speed::PANELS_ADDRESS >> 8) & 0xFF,
+        variable_speed::DDC_CONTROLLER_ADDRESS & 0xFF,
+        (variable_speed::DDC_CONTROLLER_ADDRESS >> 8) & 0xFF,
+        variable_speed::PACKET_RUN_TIME_STATE,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        0x44};
     pushDataToDriver(&buffer[0], &buffer[16]);
 
     Frame frame = driver.readFrame();
@@ -121,7 +248,8 @@ TEST_F(VariableSpeedMasterTest, it_parses_run_time_state) {
     RunTimeState expectedState;
     expectedState.time = now;
     expectedState.total_run_time = Time::fromSeconds((0x030201 * 60 * 60) + (0x00 * 60));
-    expectedState.historical_run_time =  Time::fromSeconds((0x070605 * 60 * 60) + (0x04 * 60));
+    expectedState.historical_run_time =
+        Time::fromSeconds((0x070605 * 60 * 60) + (0x04 * 60));
 
     ASSERT_EQ(runTimeState.time, expectedState.time);
     ASSERT_EQ(runTimeState.total_run_time, expectedState.total_run_time);


### PR DESCRIPTION
## What is this PR for
Stop reporting `start_signals` as `alarms` in genset driver. Jhonas get the `bit 5` output testing alarms last week which is wrong.
[sc-41366]

## How I did it
Removed bits 5 and 7 (start_signals bits).
![image](https://github.com/tidewise/drivers-genset_whisperpower_ddc/assets/79292544/9852a475-d39b-4032-8442-9c3d578392e2)

![image](https://github.com/tidewise/drivers-genset_whisperpower_ddc/assets/79292544/f3c9219f-82d3-4c15-a1e3-7a476633cce6)



## Results, How I tested
Unit test.

## Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
- [x] Run rubocop and rake tests locally
