### PR TITLE
fix: map status failure to stopped

### DIFF
--- a/src/GeneratorState.cpp
+++ b/src/GeneratorState.cpp
@@ -67,6 +67,7 @@ static power_whisperpower::GensetState::Stage statusToGensetState(GeneratorStatu
     typedef power_whisperpower::GensetState::Stage Stage;
 
     switch (status) {
+        case STATUS_FAILURE:
         case STATUS_NONE:
             return Stage::GENSET_STAGE_STOPPED;
         case STATUS_PRE_GLOW:
@@ -81,7 +82,6 @@ static power_whisperpower::GensetState::Stage statusToGensetState(GeneratorStatu
             return Stage::GENSET_STAGE_STARTING;
         case STATUS_SWITCH:
         case STATUS_STOP:
-        case STATUS_FAILURE:
             return Stage::GENSET_STAGE_STOPPING;
         case STATUS_PRESENT:
             return Stage::GENSET_STAGE_RUNNING;

--- a/test/test_GeneratorState.cpp
+++ b/test/test_GeneratorState.cpp
@@ -17,6 +17,19 @@ TEST_F(GeneratorStateTest, it_converts_to_the_common_GensetState_type)
     ASSERT_EQ(power_whisperpower::GensetState::GENSET_STAGE_STARTING, converted.stage);
 }
 
+TEST_F(GeneratorStateTest, it_converts_genset_failure_to_a_stopped_common_stage)
+{
+    GeneratorState state;
+    state.time = base::Time::fromSeconds(10);
+    state.alarms = 10;
+    state.generator_status = STATUS_FAILURE;
+
+    auto converted = state.toGensetState();
+    ASSERT_EQ(state.time, converted.time);
+    ASSERT_TRUE(converted.failure_detected);
+    ASSERT_EQ(power_whisperpower::GensetState::GENSET_STAGE_STOPPED, converted.stage);
+}
+
 TEST_F(GeneratorStateTest, it_fills_the_failure_detected_field)
 {
     GeneratorState state;


### PR DESCRIPTION
Status failure actually means that the generator is stopped. This gets over the fact that we cant regain control of the genset, but the fact is that the generator is failing.

<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [ ] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
